### PR TITLE
Reimplement how diversity, apply PEP8

### DIFF
--- a/repsys/cli.py
+++ b/repsys/cli.py
@@ -3,7 +3,7 @@ from typing import Dict
 
 import click
 import coloredlogs
-from click import Context, BadOptionUsage
+from click import Context
 
 from repsys.config import read_config
 from repsys.core import (

--- a/repsys/config.py
+++ b/repsys/config.py
@@ -83,7 +83,7 @@ def validate_dataset_config(config: DatasetConfig):
 
 
 def parse_list(arg: str, sep: str = ","):
-    if type(arg) == str:
+    if isinstance(arg, str):
         return [int(x.strip()) for x in arg.split(sep)]
     return arg
 

--- a/repsys/dataset.py
+++ b/repsys/dataset.py
@@ -139,7 +139,7 @@ def load_items(item_cols: ColumnDict, input_dir: str) -> Tuple[DataFrame, frozen
 
     csv_dtypes = {}
     for col, dt in item_cols.items():
-        if type(dt) != dtypes.Number:
+        if not isinstance(dt, dtypes.Number):
             csv_dtypes[col] = str
         else:
             params = typing.cast(dtypes.Number, dt)
@@ -446,7 +446,7 @@ class Dataset(ABC):
         # keep only columns defined in the dtypes
         items = items[item_cols.keys()]
 
-        str_cols = [col for col, dt, in item_cols.items() if type(dt) != dtypes.Number]
+        str_cols = [col for col, dt, in item_cols.items() if not isinstance(dt, dtypes.Number)]
         for col in str_cols:
             items[col] = items[col].fillna("")
             items[col] = items[col].astype(str)
@@ -614,7 +614,7 @@ class DatasetSplitter:
 
     def split(
         self, df: DataFrame
-    ) -> Tuple[Tuple[Index, DataFrame], Tuple[Index, DataFrame, DataFrame], Tuple[Index, DataFrame, DataFrame],]:
+    ) -> Tuple[Tuple[Index, DataFrame], Tuple[Index, DataFrame, DataFrame], Tuple[Index, DataFrame, DataFrame]]:
 
         df, user_activity, item_popularity = self._filter_triplets(df)
         user_index = user_activity.index

--- a/repsys/dtypes.py
+++ b/repsys/dtypes.py
@@ -64,7 +64,7 @@ ColumnDict = Dict[str, Type[DataType]]
 def filter_columns_by_type(columns: ColumnDict, dtype: Type[DataType]) -> List[str]:
     results = []
     for [col, dt] in columns.items():
-        if type(dt) == dtype:
+        if isinstance(dt, dtype):
             results.append(col)
 
     return results

--- a/repsys/evaluators.py
+++ b/repsys/evaluators.py
@@ -10,7 +10,6 @@ from pandas import DataFrame
 from scipy.sparse import issparse, csr_matrix
 from sklearn.decomposition import PCA
 from sklearn.manifold import TSNE
-from sklearn.metrics import pairwise_distances
 
 from repsys.dataset import Dataset
 from repsys.constants import CURRENT_VERSION
@@ -154,9 +153,6 @@ class ModelEvaluator:
         logger.info(f"Sorting true interactions for the maximal K={max_k}")
         true_sort_indices = sort_partially(-X_true, k=max_k)
 
-        logger.info("Computing item distances")
-        X_distances = pairwise_distances(X_train.T, metric="cosine")
-
         logger.info("Computing short-head/long-tail items")
         item_popularity = np.asarray((X_train > 0).sum(axis=0)).squeeze()
         _, long_tail_items = split_by_popularity(item_popularity)
@@ -186,7 +182,7 @@ class ModelEvaluator:
 
         logger.info("Computing user diversity")
         for k in self.diversity_k:
-            diversity = get_diversity(X_distances, predict_sort_indices, k)
+            diversity = get_diversity(X_train, predict_sort_indices, k)
             user_results[f"Diversity@{k}"] = diversity
             summary_results[f"Diversity@{k}"] = diversity.mean()
 

--- a/repsys/evaluators.py
+++ b/repsys/evaluators.py
@@ -33,7 +33,6 @@ from repsys.metrics import (
     get_clt,
     get_ndcg,
     get_novelty,
-    get_item_pop,
 )
 from repsys.model import Model
 

--- a/repsys/server.py
+++ b/repsys/server.py
@@ -50,13 +50,13 @@ def create_app(
         for col, datatype in dataset.item_cols().items():
             attributes[col] = {"dtype": str(datatype)}
 
-            if type(datatype) == dtypes.Tag:
+            if isinstance(datatype, dtypes.Tag):
                 attributes[col]["options"] = dataset.tags.get(col)
 
-            if type(datatype) == dtypes.Category:
+            if isinstance(datatype, dtypes.Category):
                 attributes[col]["options"] = dataset.categories.get(col)
 
-            if type(datatype) == dtypes.Number:
+            if isinstance(datatype, dtypes.Number):
                 hist = dataset.histograms.get(col)
                 attributes[col]["bins"] = hist[1].tolist()
 


### PR DESCRIPTION
- Reimplement how diversity is measured to prevent from allocating (items, items) dense similarity matrix
- Remove unused imports and fix check datatypes to comply with PEP8